### PR TITLE
new function NodeByAttributeValue & FindNodes (both working with multiple find parameters) + bugfix

### DIFF
--- a/nativexml/NativeXml.pas
+++ b/nativexml/NativeXml.pas
@@ -7228,9 +7228,9 @@ var
   Node: TXmlNode;
   CharData: TsdCharData;
   SubstituteText: Utf8String;
-  {$ifdef D5UP}
+  {$ifndef D7UP}
   Src: PChar;
-  {$endif D5UP}
+  {$endif D7UP}
 begin
   CharDataCount := 0;
   Result := 0; // ReferencesCount

--- a/nativexml/simdesign.inc
+++ b/nativexml/simdesign.inc
@@ -149,8 +149,16 @@
   {$define D16UP}
 {$endif}
 
-// Delphi 10.1
+// Delphi 10.1 Berlin
 {$ifdef VER310}
+  {$define D7UP}
+  {$define D10UP}
+  {$define D15UP}
+  {$define D16UP}
+{$endif}
+
+// Delphi 10.2 Tokyo
+{$ifdef VER320}
   {$define D7UP}
   {$define D10UP}
   {$define D15UP}

--- a/nativexml/simdesign.inc
+++ b/nativexml/simdesign.inc
@@ -148,3 +148,11 @@
   {$define D15UP}
   {$define D16UP}
 {$endif}
+
+// Delphi 10.1
+{$ifdef VER310}
+  {$define D7UP}
+  {$define D10UP}
+  {$define D15UP}
+  {$define D16UP}
+{$endif}


### PR DESCRIPTION
new function NodeByAttributeValue find node with multiple NodeName,AttribName and AttribValue
+ new function FindNodes find node with multiple NodeName
+ bugfix (I apologize, but I don't remember history of emergence of a bug any more)