### PR TITLE
chore(html): Fix HTML doc examples to use TNativeXml.Create(nil)

### DIFF
--- a/doc/000058.html
+++ b/doc/000058.html
@@ -32,7 +32,7 @@ var
   ADoc: <A HREF="000155.html" CLASS="link">TNativeXml</A>;
 begin
   Memo1.Lines.Clear;
-  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>;
+  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>(nil);
   try
     ADoc.LoadFromFile(Edit1.Text);
     ADoc.XmlFormat := xfReadable;

--- a/doc/000061.html
+++ b/doc/000061.html
@@ -33,7 +33,7 @@ var
   ADoc: <A HREF="000155.html" CLASS="link">TNativeXml</A>;
 begin
   Memo1.Lines.Clear;
-  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>;
+  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>(nil);
   try
     ADoc.LoadFromFile(Edit1.Text);
     if assigned(ADoc.Root) then with ADoc.Root do

--- a/doc/000062.html
+++ b/doc/000062.html
@@ -33,7 +33,7 @@ var
   ADoc: <A HREF="000155.html" CLASS="link">TNativeXml</A>;
 begin
   Memo1.Lines.Clear;
-  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>;
+  ADoc := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>(nil);
   try
     ADoc.OnNodeNew    := DoNodeNew;
     ADoc.OnNodeLoaded := DoNodeLoaded;

--- a/doc/000063.html
+++ b/doc/000063.html
@@ -44,6 +44,7 @@ var
 begin
   // Create new document with a rootnode called &quot;Root&quot;
   ADoc := <A HREF="000172.html" CLASS="link">TNativeXml.CreateName</A>('Root');
+  ADoc.Charset := 'windows-1252';
   try
     // Add a subnode with name &quot;Customer&quot;
     with ADoc.Root.NodeNew('Customer') do begin

--- a/doc/000064.html
+++ b/doc/000064.html
@@ -79,7 +79,7 @@ Loading XML files with extended characters</DIV>
 <PRE CLASS="code">
 function CreateXMLAndLoadFromFile(AFilename: string): <A HREF="000155.html" CLASS="link">TNativeXml</A>;
 begin
-  Result := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>;
+  Result := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>(nil);
   Result.LoadFromFile(AFilename);  
 end;
 </PRE></DIV>
@@ -90,7 +90,7 @@ end;
 <PRE CLASS="code">
 function CreateXMLAndLoadFromStream(S: TStream): <A HREF="000155.html" CLASS="link">TNativeXml</A>;
 begin
-  Result := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>;
+  Result := <A HREF="000170.html" CLASS="link">TNativeXml.Create</A>(nil);
   Result.LoadFromStream(S);  
 end;
 </PRE></DIV>


### PR DESCRIPTION
Updated several .html documentation files to fix code examples that incorrectly called TNativeXml.Create without a parameter which would cause error E2035: Not enough actual parameters on the Create. The NativeXml.pas constructor Create(AOwner: TComponent) requires one so nil was passed. Note that Create suppresses the first line header (version, encoding) of a saved xml file versus CreateName('Root'). Fix 000063.html code to match file.